### PR TITLE
Correct the required attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ end
   <SEO.juice
     conn={@conn}
     config={MyAppWeb.SEO.config()}
+    item={SEO.item(@conn)}
     page_title={assigns[:page_title]}
   />
 </head>

--- a/lib/seo.ex
+++ b/lib/seo.ex
@@ -67,6 +67,7 @@ defmodule SEO do
     <SEO.juice
       conn={@conn}
       config={MyAppWeb.SEO.config()}
+      item={SEO.item(@conn)}
       page_title={assigns[:page_title]}
     />
   </head>


### PR DESCRIPTION
Because of this line
https://github.com/dbernheisel/phoenix_seo/blob/main/lib/seo.ex#L104

The examples given for `SEO.juice` won't work
In the PhoenixLiveView documentation it states
`Attributes can provide default values that are automatically merged into the assigns map`
If no item attribute is given then a `nil` is inserted for `item` in `assigns`

When this line runs https://github.com/dbernheisel/phoenix_seo/blob/main/lib/seo.ex#L125
`assign_new(:item, fn -> SEO.item(assigns[:conn]) end)` will not write the attribute since there is already a `nil` for `item` in  `assigns`.

It's probably best to remove the default attribute and add a test for the case of rendering the component without an `item` attribute, but want to get this out there if someone else is scratching their head like me on why it's only rendering the base config.