### PR TITLE
Fix item defaulting to nil

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-erlang 25.1.1
-elixir 1.14.1-otp-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased
+
+- Fix behavior when no item is provided. Component was defaulting to nil for
+  item when didn't let fallback to work. Thank you @hwatkins.
+
 ## 0.1.7 (2022-12-08)
 
 - BREAKING: simplify OpenGraph fields `:type` and `:type_detail` into one

--- a/lib/seo.ex
+++ b/lib/seo.ex
@@ -101,7 +101,6 @@ defmodule SEO do
   )
 
   attr(:item, :any,
-    default: nil,
     doc:
       "Item to render that implements SEO protocols. `SEO.item(@conn)` will be used if not supplied."
   )

--- a/test/seo_test.exs
+++ b/test/seo_test.exs
@@ -13,6 +13,14 @@ defmodule SEOTest do
   end
 
   describe "juice" do
+    test "renders item from conn when item not provided directly" do
+      item = [title: "foo"]
+      conn = Plug.Conn.put_private(%Plug.Conn{}, SEO.key(), item)
+      result = render_component(&SEO.juice/1, conn: conn)
+
+      assert result =~ ~s|<title>foo</title>|
+    end
+
     test "renders everything from item" do
       item = %MyApp.Article{title: "Title", description: "Description"}
       result = render_component(&SEO.juice/1, build_assigns(item, json_library: Jason))


### PR DESCRIPTION
This fixes the behavior when `item` is not directly provided. The component is supposed to grab the item from the conn/socket when not provided--instead the component was defaulting to nil which didn't allow `assign_new` to happen.

Thanks to @hwatkins in #7 