### PR TITLE
Fix twitter card value from config is always overridden by default value

### DIFF
--- a/lib/seo/twitter.ex
+++ b/lib/seo/twitter.ex
@@ -38,7 +38,7 @@ defmodule SEO.Twitter do
     :app_id_googleplay,
     :app_url_googleplay,
     :app_country,
-    card: :summary
+    :card
   ]
 
   @type t :: %__MODULE__{

--- a/lib/seo/twitter.ex
+++ b/lib/seo/twitter.ex
@@ -132,8 +132,9 @@ defmodule SEO.Twitter do
 
     ~H"""
     <%= if @item do %>
+    <%= if @item.card do %>
     <meta name="twitter:card" content={@item.card} />
-    <%= if @item.title do %>
+    <% end %><%= if @item.title do %>
     <meta name="twitter:title" content={@item.title} />
     <% end %><%= if @item.description do %>
     <meta name="twitter:description" content={@item.description} />

--- a/test/seo/twitter_test.exs
+++ b/test/seo/twitter_test.exs
@@ -8,59 +8,49 @@ defmodule SEO.TwitterTest do
 
   describe "card" do
     test "not rendered if no value is set by config and attrs" do
-      item = %{}
-      default = %{}
-
-      result = render_component(&Twitter.meta/1, build_assigns(item, default))
+      result = render_component(&Twitter.meta/1, [])
 
       assert not String.contains?(result, ~s(<meta name="twitter:card"))
     end
 
-    test "default is rendered if card is not provided in attrs" do
+    test "default is rendered if card is not provided by attrs" do
       for card <- @valid_card_values do
-        item = %{}
-        default = Twitter.build(card: card)
+        default = build_item(card: card)
+        assigns = [config: default]
 
-        result = render_component(&Twitter.meta/1, build_assigns(item, default))
+        result = render_component(&Twitter.meta/1, assigns)
 
         assert String.contains?(result, ~s(<meta name="twitter:card" content="#{card}">))
       end
     end
 
-    test "default is rendered if card in attrs is invalid" do
-      item = %{card: :invalid}
-
+    test "default is rendered if card in attrs is unspecified" do
       for card <- @valid_card_values do
-        default = Twitter.build(card: card)
+        default = build_item(card: card)
+        item = build_item(%{})
 
-        result = render_component(&Twitter.meta/1, build_assigns(item, default))
+        assigns = [config: default, item: item]
+
+        result = render_component(&Twitter.meta/1, assigns)
 
         assert String.contains?(result, ~s(<meta name="twitter:card" content="#{card}">))
       end
     end
 
-    test "not rendered if card in attrs is invalid" do
-      item = %{card: :invalid}
-      default = %{}
-
-      result = render_component(&Twitter.meta/1, build_assigns(item, default))
-
-      assert not String.contains?(result, ~s(<meta name="twitter:card"))
-    end
-
-    test "attrs is rendered if valid" do
-      default = Twitter.build(card: :summary_large_image)
+    test "attrs value is rendered" do
+      default = build_item(card: :summary_large_image)
 
       for card <- @valid_card_values do
-        item = %{card: card}
+        item = build_item(%{card: card})
 
-        result = render_component(&Twitter.meta/1, build_assigns(item, default))
+        assigns = [config: default, item: item]
+
+        result = render_component(&Twitter.meta/1, assigns)
 
         assert String.contains?(result, ~s(<meta name="twitter:card" content="#{card}">))
       end
     end
   end
 
-  defp build_assigns(item, default),
-    do: [item: Twitter.Build.build(item, %Plug.Conn{}), config: default]
+  defp build_item(item), do: Twitter.Build.build(item, %Plug.Conn{})
 end

--- a/test/seo/twitter_test.exs
+++ b/test/seo/twitter_test.exs
@@ -1,0 +1,66 @@
+defmodule SEO.TwitterTest do
+  use ExUnit.Case, async: true
+  import Phoenix.LiveViewTest
+
+  alias SEO.Twitter
+
+  @valid_card_values [:summary, :summary_large_image, :app, :player]
+
+  describe "card" do
+    test "not rendered if no value is set by config and attrs" do
+      item = %{}
+      default = %{}
+
+      result = render_component(&Twitter.meta/1, build_assigns(item, default))
+
+      assert not String.contains?(result, ~s(<meta name="twitter:card"))
+    end
+
+    test "default is rendered if card is not provided in attrs" do
+      for card <- @valid_card_values do
+        item = %{}
+        default = Twitter.build(card: card)
+
+        result = render_component(&Twitter.meta/1, build_assigns(item, default))
+
+        assert String.contains?(result, ~s(<meta name="twitter:card" content="#{card}">))
+      end
+    end
+
+    test "default is rendered if card in attrs is invalid" do
+      item = %{card: :invalid}
+
+      for card <- @valid_card_values do
+        default = Twitter.build(card: card)
+
+        result = render_component(&Twitter.meta/1, build_assigns(item, default))
+
+        assert String.contains?(result, ~s(<meta name="twitter:card" content="#{card}">))
+      end
+    end
+
+    test "not rendered if card in attrs is invalid" do
+      item = %{card: :invalid}
+      default = %{}
+
+      result = render_component(&Twitter.meta/1, build_assigns(item, default))
+
+      assert not String.contains?(result, ~s(<meta name="twitter:card"))
+    end
+
+    test "attrs is rendered if valid" do
+      default = Twitter.build(card: :summary_large_image)
+
+      for card <- @valid_card_values do
+        item = %{card: card}
+
+        result = render_component(&Twitter.meta/1, build_assigns(item, default))
+
+        assert String.contains?(result, ~s(<meta name="twitter:card" content="#{card}">))
+      end
+    end
+  end
+
+  defp build_assigns(item, default),
+    do: [item: Twitter.Build.build(item, %Plug.Conn{}), config: default]
+end

--- a/test/seo/twitter_test.exs
+++ b/test/seo/twitter_test.exs
@@ -10,7 +10,7 @@ defmodule SEO.TwitterTest do
     test "not rendered if no value is set by config and attrs" do
       result = render_component(&Twitter.meta/1, [])
 
-      assert not String.contains?(result, ~s(<meta name="twitter:card"))
+      assert not String.contains?(result, ~s|<meta name="twitter:card"|)
     end
 
     test "default is rendered if card is not provided by attrs" do
@@ -20,7 +20,7 @@ defmodule SEO.TwitterTest do
 
         result = render_component(&Twitter.meta/1, assigns)
 
-        assert String.contains?(result, ~s(<meta name="twitter:card" content="#{card}">))
+        assert String.contains?(result, ~s|<meta name="twitter:card" content="#{card}">|)
       end
     end
 
@@ -33,7 +33,7 @@ defmodule SEO.TwitterTest do
 
         result = render_component(&Twitter.meta/1, assigns)
 
-        assert String.contains?(result, ~s(<meta name="twitter:card" content="#{card}">))
+        assert String.contains?(result, ~s|<meta name="twitter:card" content="#{card}">|)
       end
     end
 
@@ -47,7 +47,7 @@ defmodule SEO.TwitterTest do
 
         result = render_component(&Twitter.meta/1, assigns)
 
-        assert String.contains?(result, ~s(<meta name="twitter:card" content="#{card}">))
+        assert String.contains?(result, ~s|<meta name="twitter:card" content="#{card}">|)
       end
     end
   end

--- a/test/support/my_app_web_impl.ex
+++ b/test/support/my_app_web_impl.ex
@@ -75,7 +75,11 @@ end
 
 defimpl SEO.Twitter.Build, for: MyApp.Article do
   def build(article, _conn) do
-    SEO.Twitter.build(description: article.description, title: article.title)
+    SEO.Twitter.build(
+      description: article.description,
+      title: article.title,
+      card: :summary
+    )
   end
 end
 


### PR DESCRIPTION
closes #12 

- Remove default `summary` value for `card` from  `SEO.Twitter`
- Prevent `twitter:card` meta tag being rendered if the value is nil